### PR TITLE
add note to use bootstrap-sass, for compatible with glyphicons.

### DIFF
--- a/source/basics/asset-pipeline.markdown
+++ b/source/basics/asset-pipeline.markdown
@@ -50,6 +50,14 @@ Once you've added a dependency on these gems, any images and fonts from the gem 
 
 If you want to refer to a gem stylesheet or JS file directly from your HTML rather than including it in your own assets, you'll need to import it explicitly in `config.rb`:
 
+**Note:** You should add this line to `config.rb`:
+
+```ruby
+require "bootstrap-sass/sass_functions.rb"
+```
+
+ It's hotfix for bootstrap-sass specific.
+
 ```ruby
 ready do
   sprockets.import_asset 'jquery-mobile'


### PR DESCRIPTION
Hi.

I found a problem when using "bootstrap-sass" gem with middleman (3.3.2); glyphicons are not working.

In this document, we should add only this line to Gemfile

```
gem "bootstrap-sass", :require => false
```

but, I think this line are also needed to use bootstrap-sass with middleman... isn't it?

```ruby
# in config.rb
require "bootstrap-sass/sass_functions.rb"
```
I think it's a trap in the document.