### PR TITLE
Fix unnecessary scrollbars

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,21 +1,25 @@
 source 'https://rubygems.org'
 
 # Core
-gem "middleman", '4.0.0.alpha.5'
-gem "middleman-autoprefixer"
-gem "middleman-livereload"
+gem 'middleman', '4.0.0.alpha.5'
+gem 'middleman-autoprefixer'
+gem 'middleman-livereload'
 
 # Templating Engines
-gem "redcarpet"
-gem "builder"
+gem 'redcarpet'
+gem 'builder'
+gem 'sass'
 
 # Asset Pipeline Gems
-gem "font-awesome-middleman"
-gem "neat"
-gem "bourbon"
-gem "jquery-middleman"
+gem 'font-awesome-middleman'
+gem 'neat'
+gem 'bourbon'
+gem 'jquery-middleman'
+
+# Windows Support
+gem 'wdm' if Gem.win_platform?
 
 # Debug
-# gem "pry"
-# gem "pry-byebug"
-# gem "pry-stack_explorer"
+# gem 'pry'
+# gem 'pry-byebug'
+# gem 'pry-stack_explorer'

--- a/source/stylesheets/base/_typography.scss
+++ b/source/stylesheets/base/_typography.scss
@@ -102,5 +102,5 @@ code {
   font-family: $monospace-font-family;
   font-size: 1rem;
   padding:  0.05em 0.5em;
-  overflow: scroll;
+  overflow: auto;
 }


### PR DESCRIPTION
Currently every code block has scrollbars (for me on chrome/firefox at least), this patch makes them appear only when needed.
Also added some stuff to the `Gemfile` to silence warnings on Windows.
