### PR TITLE
Update title for Turing Incomplete

### DIFF
--- a/data/sites.yml
+++ b/data/sites.yml
@@ -264,4 +264,4 @@ blogs:
     title: "Philadelphia Ruby user group"
   - url: http://turing.cool
     source: https://github.com/turing-incomplete/turing-incomplete
-    title: "A podcast about programming"
+    title: "Turing Incomplete - A Podcast About Programming"


### PR DESCRIPTION
I added the full title for the site turing.cool.