### PR TITLE
Add link to thoughtbot from footer image

### DIFF
--- a/source/localizable/_footer.html.erb
+++ b/source/localizable/_footer.html.erb
@@ -24,8 +24,15 @@
       </article>
     </div>
     <div class="footer-column footer-right">
-      <p class="footer-credit">Site proudly designed by</p>
-      <span class="footer-thoughtbot-logo"></span>
+      <a href="https://thoughtbot.com?utm_source=middleman">
+        <span class="footer-thoughtbot-logo"></span>
+      </a>
+      <p class="footer-credit">
+        thoughtbot designed this site and is
+
+        <%= link_to "available for hire",
+          "https://thoughtbot.com/hire-us?utm_source=middleman" %>.
+      </p>
     </div>
   </div>
 </footer>

--- a/source/stylesheets/modules/_footer.scss
+++ b/source/stylesheets/modules/_footer.scss
@@ -49,7 +49,9 @@
   }
 }
 
-.footer-open-source-credit a {
+.footer-credit a,
+.footer-open-source-credit a,
+{
   font-weight: $font-weight-normal;
   text-decoration: underline;
 }


### PR DESCRIPTION
Make it more obvious that we're available for hire.

Looks like this:

![screen shot 2015-03-09 at 11 03 41 am](https://cloud.githubusercontent.com/assets/198/6561109/f7646ec4-c64b-11e4-93f2-a4411ada2676.png)

What do you think?