### PR TITLE
Increase text color contrast for readability

### DIFF
--- a/source/stylesheets/base/_typography.scss
+++ b/source/stylesheets/base/_typography.scss
@@ -86,7 +86,8 @@ picture {
 }
 
 code {
-  background-color: lighten($mm-slate-gray, 37%);
+  color: darken($base-font-color, 20%);
+  background-color: lighten($base-font-color, 64%);
   border-radius: $base-border-radius;
   font-family: $monospace-font-family;
   font-size: 1rem;

--- a/source/stylesheets/base/_variables.scss
+++ b/source/stylesheets/base/_variables.scss
@@ -43,7 +43,7 @@ $mm-light-gray: #c0c0c0;
 $mm-blue: #4280ca;
 
 // Font Colors
-$base-font-color: darken($mm-slate-gray, 8%);
+$base-font-color: darken($mm-slate-gray, 25%);
 $base-accent-color: $mm-yellow;
 $header-font-color: $dark-gray;
 $secondary-accent-color: $mm-blue;

--- a/source/stylesheets/modules/_documentation-nav.scss
+++ b/source/stylesheets/modules/_documentation-nav.scss
@@ -31,7 +31,7 @@
   }
 
   @include placeholder {
-    color: $mm-light-gray;
+    color: lighten($base-font-color, 30%);
   }
 }
 
@@ -40,7 +40,7 @@
 }
 
 .docs-section-heading {
-  color: $mm-light-gray;
+  color: lighten($base-font-color, 25%);
   font-size: $base-font-size * 0.85;
   font-weight: $font-weight-bold;
   letter-spacing: 2px;
@@ -56,7 +56,7 @@
   }
 
   a {
-    color: darken($mm-slate-gray, 10);
+    color: $base-font-color;
     display: block;
     padding: 0.34em 0.5em;
     transition: all 0.15s ease;


### PR DESCRIPTION
It's kinda hard to read the current documentation due to low contrast, especially on non-Retina/crappy screens.

This PR is my attempt at increasing the contrast while keeping the main colors as much the same as possible. The W3C recommends a [minimum contrast ratio](http://www.w3.org/TR/WCAG/#visual-audio-contrast-contrast) of 4.5:1, which I think is still violated in some places even after these changes (e.g. comments in code sections) but at least not in the main text.

I think the [white on yellow](https://leaverou.github.io/contrast-ratio/#white-on-%23f3c859) nav bar at the top is also not great in terms of contrast, but I thought changing that might be a bit much.