### PR TITLE
use height instead of padding for documentation search field

### DIFF
--- a/source/stylesheets/modules/_documentation-nav.scss
+++ b/source/stylesheets/modules/_documentation-nav.scss
@@ -17,7 +17,9 @@
   @include fill-parent;
   border: 1px solid $mm-slate-gray;
   margin-bottom: 0;
-  padding: 1em 1.9em;
+  height: $base-font-size*2;
+  padding: 0 1.9em;
+  line-height: $base-font-size*2;
 
   &:focus,
   &:hover {


### PR DESCRIPTION
fixes issue with firefox clipping text in the input field [close #501]. looks like things are a little more consistent in IE as well (though I'll admit I only check on IE 10)