### PR TITLE
clarified example

### DIFF
--- a/source/advanced/file_size_optimization.html.markdown
+++ b/source/advanced/file_size_optimization.html.markdown
@@ -37,13 +37,7 @@ enable unsafe optimizations and mangle top-level variable names like this:
 
 ``` ruby
 activate :minify_javascript
-set :js_compressor, Uglifier.new(:mangle => {:toplevel => true}, :compress => {:unsafe => true})
-```
-
-Do not forget to put this in your Gemfile:
-
-``` ruby
-gem "uglifier"
+set :js_compressor, ::Uglifier.new(:mangle => {:toplevel => true}, :compress => {:unsafe => true})
 ```
 
 If you have `asset_hash` activated, are building your site on multiple servers


### PR DESCRIPTION
* example as is throws error
* corrected per gh issue 500 with prefixing with :: -> https://github.com/middleman/middleman/issues/900#issuecomment-51356664
* other possible fix, update example with :: namespace resolution operator so it works without any changes
* uglifier is a dependency of middleman gem, so removed block to include it: https://rubygems.org/gems/middleman/versions/3.4.0