### PR TITLE
Fix FormKeep logo not showing up

### DIFF
--- a/source/stylesheets/modules/_footer.scss
+++ b/source/stylesheets/modules/_footer.scss
@@ -82,7 +82,7 @@
 .footer-formkeep-logo {
   @include size(em(200) em(71));
   display: inline-block;
-  background-image: url('formkeep-logo.svg');
+  background-image: url('/images/formkeep-logo.svg');
   background-repeat: no-repeat;
   background-size: 100% 100%;
 }


### PR DESCRIPTION
The url was linking to the wrong place.