### PR TITLE
Fix stretched FormKeep logo in Firefox

### DIFF
--- a/source/stylesheets/modules/_footer.scss
+++ b/source/stylesheets/modules/_footer.scss
@@ -84,5 +84,5 @@
   display: inline-block;
   background-image: url('/images/formkeep-logo.svg');
   background-repeat: no-repeat;
-  background-size: 100% 100%;
+  background-size: 100%;
 }


### PR DESCRIPTION
How it looks in Firefox right before:
<img width="456" alt="Stretched FormKeep logo in Firefox" src="https://cloud.githubusercontent.com/assets/578554/10265252/82d26b76-6a31-11e5-9ad8-fc8c914a7d2b.png">
... and after.
<img width="444" alt="Normal FormKeep logo in Firefox"" src="https://cloud.githubusercontent.com/assets/578554/10265258/b6e440d8-6a31-11e5-86a2-31be1856a621.png">
