### PR TITLE
remove unnecessary require

### DIFF
--- a/source/basics/start_new_site.html.markdown
+++ b/source/basics/start_new_site.html.markdown
@@ -59,7 +59,6 @@ If you've already initialized a project and just want the config.ru for linking
 with pow or other development server its contents are simply:
 
 ```
-require 'rubygems'
 require 'middleman/rack'
 run Middleman.server
 ```

--- a/source/localizable/basics/start_new_site.jp.html.markdown
+++ b/source/localizable/basics/start_new_site.jp.html.markdown
@@ -59,7 +59,6 @@ $ middleman init my_new_project --rack
 config.ru が欲しい場合は, 次の内容を記述してください:
 
 ```
-require 'rubygems'
 require 'middleman/rack'
 run Middleman.server
 ```


### PR DESCRIPTION
`require 'rubygems'` is already required in Ruby 1.9 or later.