### PR TITLE
Fix typo in project_templates.jp

### DIFF
--- a/source/localizable/advanced/project_templates.jp.html.markdown
+++ b/source/localizable/advanced/project_templates.jp.html.markdown
@@ -55,7 +55,7 @@ $ middleman init my_new_mobile_project --template=mobile
 
 ### コミュニティプロジェクトテンプレート
 
-こちらにもいくつか [コミュニティで開発されたテンプレート](https://directory.middlemanapp.com/# /templates/all) があります。
+こちらにもいくつか [コミュニティで開発されたテンプレート](https://directory.middlemanapp.com/#/templates/all) があります。
 
 [HTML5 Boilerplate]: http://html5boilerplate.com/
 [SMACSS]: http://smacss.com/


### PR DESCRIPTION
I found a broken link in Japanese translation.

See: https://middlemanapp.com/jp/advanced/project_templates/

I removed a needless white space.