### PR TITLE
Add HireArt dev blog to list

### DIFF
--- a/data/sites.yml
+++ b/data/sites.yml
@@ -1,4 +1,6 @@
 built:
+  - url: http://code.hireart.com
+    title: Code at HireArt
   - url: http://joshlain.cz
     title: Josh Laincz
   - url: https://software-berater.net/


### PR DESCRIPTION
We built our developer blog on Middleman.