### PR TITLE
Add HireArt dev blog to list

### DIFF
--- a/data/sites.yml
+++ b/data/sites.yml
@@ -273,6 +273,8 @@ built:
 mobile:
   - url: http://pollev.com
 blogs:
+  - url: http://code.hireart.com
+    title: Code at HireArt
   - url: https://viljamis.com
     title: "Viljami Salminen"
   - url: http://www.downrightlies.net


### PR DESCRIPTION
We released our developer blog on Middleman. Adding it correctly to the "blogs" section this time.