### PR TITLE
Updated link to Padrino Render Helper documentation page.

### DIFF
--- a/source/basics/partials.html.markdown
+++ b/source/basics/partials.html.markdown
@@ -74,4 +74,4 @@ Then, within the partial, you can set the text appropriately as follows:
 
 Read the [Padrino Render Helpers] documentation for more information (located towards the bottom of the Application Helpers guide).
 
-[Padrino Render Helpers]: http://padrinorb.com/guides/application-helpers/
+[Padrino Render Helpers]: http://padrinorb.com/guides/application-helpers/render-helpers/

--- a/source/localizable/basics/partials.jp.html.markdown
+++ b/source/localizable/basics/partials.jp.html.markdown
@@ -74,4 +74,4 @@ admin レイアウトでは次のように:
 
 詳細については [Padrino Render Helpers] のドキュメントを参照してください。(リンク先ページの下の方にあります)
 
-[Padrino Render Helpers]: http://padrinorb.com/guides/application-helpers/
+[Padrino Render Helpers]: http://padrinorb.com/guides/application-helpers/render-helpers/


### PR DESCRIPTION
Under the `Partials` page, the link titled "Padrino Render Helpers" points to a broken link.  Updated it to point to the correct page of the Padrino docs.