### PR TITLE
Fix `wrap_layout` example

### DIFF
--- a/source/basics/layouts.html.markdown
+++ b/source/basics/layouts.html.markdown
@@ -176,7 +176,7 @@ page "blog/*", :layout => :article_layout
 That `layouts/article_layout.erb` layout would look like this
 
 ``` html
-<% wrap_layout :layout do %>
+<%= wrap_layout :layout do %>
   <article>
     <%= yield %>
   </article>

--- a/source/basics/layouts.html.markdown
+++ b/source/basics/layouts.html.markdown
@@ -164,6 +164,12 @@ tell all the blog articles to use a `article_layout` layout instead of the
 default `layout`. In `config.rb`:
 
 ``` ruby
+activate :blog do |blog|
+  blog.layout = "article_layout"
+end
+
+# Or:
+
 page "blog/*", :layout => :article_layout
 ```
 

--- a/source/localizable/basics/layouts.jp.html.markdown
+++ b/source/localizable/basics/layouts.jp.html.markdown
@@ -164,6 +164,12 @@ blog 記事が blog/my-article.html.markdown に置かれているとします�
 指定します。 config.rb を編集:
 
 ``` ruby
+activate :blog do |blog|
+  blog.layout = "article_layout"
+end
+
+# または:
+
 page "blog/*", :layout => :article_layout
 ```
 

--- a/source/localizable/basics/layouts.jp.html.markdown
+++ b/source/localizable/basics/layouts.jp.html.markdown
@@ -176,7 +176,7 @@ page "blog/*", :layout => :article_layout
 `layouts/article_layout.erb` は次のようになります:
 
 ``` html
-<% wrap_layout :layout do %>
+<%= wrap_layout :layout do %>
   <article>
     <%= yield %>
   </article>


### PR DESCRIPTION
This fixes the ERB tag used to invoke `wrap_layout` by changing it to an output tag. The example does not work when a non-outputting execution tag is used.

This also updates the example for setting a nested blog layout by showing how to do so within the `activate :blog` block. Readers coming from the [Layouts section of the Blogging page](https://middlemanapp.com/basics/blogging/#layouts) might get confused when they see the invocation of `page` with a `:layout` option, in that they might think they need to use both approaches. This change indicates that either is possible.

Thanks for these great guides!