### PR TITLE
Add usage of `config` from templates and helpers

### DIFF
--- a/source/advanced/configuration.html.markdown
+++ b/source/advanced/configuration.html.markdown
@@ -62,3 +62,37 @@ configure :build do
   activate :minify_css
 end
 ```
+
+## Access Configuration from Templates and Helpers
+
+Configuration is exposed in the context of templates and helpers.
+
+First, make a configuration setting.
+
+```ruby
+# config.rb
+
+configure :build do
+  config[:host] = "http://www.example.com"
+end
+```
+
+Then, access it by invoking `config`.
+
+```erb
+<!-- layouts/application.erb -->
+
+<h1>
+  Thanks for visiting <%= config[:host] %>!
+</h1>
+```
+
+```ruby
+# helpers/custom_helpers.rb
+
+module CustomHelpers
+  def home_link
+    link_to "Home", config[:host]
+  end
+end
+```


### PR DESCRIPTION
This adds a section detailing how to access configuration settings made in `config.rb` from templates and helpers.

Thanks @tdreyno for your help clarifying this!