### PR TITLE
Add Trailpost to list of websites built using Middleman. Yay.

### DIFF
--- a/data/sites.yml
+++ b/data/sites.yml
@@ -296,6 +296,8 @@ built:
     source: https://github.com/brug-be/rubybelgium
   - url: http://www.citusdata.com
     title: "Citus Data"
+  - url: https://www.trailpost.com/
+    title: "Trailpost Outdoors"
 mobile:
   - url: http://pollev.com
 blogs:


### PR DESCRIPTION
Howdy, we just relaunched our expensive complex marketing website as a much less expensive Middleman site on S3+CloudFront+ACM. :heart: Middleman.