### PR TITLE
Add Software Niagara to sites

### DIFF
--- a/data/sites.yml
+++ b/data/sites.yml
@@ -308,6 +308,9 @@ built:
   - url: http://www.cafescidurham.co.uk
     title: "Cafe Sci Durham City"
     source: https://github.com/JBorrow/Cafe-Sci-2016
+  - url: http://www.softwareniagara.com
+    title: "Software Niagara"
+    source: https://github.com/softwareniagara/softwareniagara.com
 mobile:
   - url: http://pollev.com
 blogs:


### PR DESCRIPTION
I'm adding the Software Niagara website to the "Built with Middleman" section of the site. This site was built with Middleman 3 two years ago and just rebuilt with Middleman 4. Makes use of Middleman data, webpack, and functional css. 