### PR TITLE
docs(docsearch): upgrade docsearch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "babel-preset-stage-0": "^6.1.18",
     "babel-runtime": "^6.1.21",
     "clean-webpack-plugin": "^0.1.3",
-    "docsearch.js": "^2.0.7",
+    "docsearch.js": "^2.1.8",
     "exports-loader": "^0.6.2",
     "imports-loader": "^0.6.4",
     "webpack": "^1.10.5"


### PR DESCRIPTION
Hi, we fixed some bugs in docsearch, like displaying a "no results" screen when there are .. no results.

Could you rebuild the middleman website with that new version? Thanks!