### PR TITLE
Update broken link to Haml site

### DIFF
--- a/source/basics/development_cycle.html.markdown
+++ b/source/basics/development_cycle.html.markdown
@@ -8,7 +8,7 @@ title: The Development Cycle
 
 The Middleman separates your development and production code from the start.
 This allows you to utilize a bevy of tools (such as
-[Haml](http://haml-lang.com), [Sass](http://sass-lang.com),
+[Haml](http://haml.info), [Sass](http://sass-lang.com),
 [CoffeeScript](http://coffeescript.org/), etc.) during development that are
 unnecessary or undesirable in production.  We refer to these environments as
 The Development Cycle and the Static Site.


### PR DESCRIPTION
Haml changed their url to http://haml.info, this updates the link on the Development Cycle page.