### PR TITLE
Add ichack.org to list of sites using middleman

### DIFF
--- a/data/sites.yml
+++ b/data/sites.yml
@@ -331,6 +331,8 @@ built:
     source: https://github.com/softwareniagara/softwareniagara.com
   - url: https://eazybi.com/
     title: "eazyBI"
+  - url: http://ichack.org/
+    title: "IC Hack"
 mobile:
   - url: http://pollev.com
 blogs:


### PR DESCRIPTION
IC Hack is Imperial College London's annual hackathon