### PR TITLE
Add a setup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 .rbenv-version
 .rvmrc
 .sass-cache
-bin
 build
 Gemfile.lock
 source/mint/config/db.php

--- a/README.md
+++ b/README.md
@@ -12,8 +12,24 @@ markup.
 
 ## How to run the site locally
 
-Make sure you have Ruby 1.9.3+, Bundler and [npm](https://docs.npmjs.com) installed. Then clone this repo, run `npm install` and `bundle install`.
-Then run `bundle exec middleman server` to start the server at `http://localhost:4567`
+Make sure you have Ruby 1.9.3+, [Bundler] and [npm] installed.
+
+1. Set up your machine:
+
+  ```bash
+  bin/setup
+  ```
+
+1. Start the server:
+
+  ```bash
+  bundle exec middleman server
+  ```
+
+1. Open <http://localhost:4567>.
+
+[Bundler]: http://bundler.io/
+[npm]: https://docs.npmjs.com/
 
 ## Mailing List
 

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# Run this script to setup the app
+
+# Exit if any subcommand fails
+set -e
+
+# Set up Ruby dependencies
+gem install bundler --conservative
+bundle check || bundle install
+
+# Set up Node dependencies
+npm install


### PR DESCRIPTION
This let’s contributors run one simple script (`bin/setup`) which should set their machine up, rather than a few scrips to work through.