### PR TITLE
Check Gemfile.lock into version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@
 .sass-cache
 bin
 build
-Gemfile.lock
 source/mint/config/db.php
 /.tmp/
 /node_modules/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,132 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (5.0.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
+    autoprefixer-rails (6.7.2)
+      execjs
+    backports (3.6.8)
+    bourbon (4.3.2)
+      sass (~> 3.4)
+      thor (~> 0.19)
+    builder (3.2.3)
+    coffee-script (2.4.1)
+      coffee-script-source
+      execjs
+    coffee-script-source (1.12.2)
+    compass-import-once (1.0.5)
+      sass (>= 3.2, < 3.5)
+    concurrent-ruby (1.0.4)
+    contracts (0.13.0)
+    dotenv (2.2.0)
+    em-websocket (0.5.1)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0.6.0)
+    erubis (2.7.0)
+    eventmachine (1.2.2)
+    execjs (2.7.0)
+    fast_blank (1.0.0)
+    fastimage (2.0.1)
+      addressable (~> 2)
+    ffi (1.9.17)
+    haml (4.0.7)
+      tilt
+    hamster (3.0.0)
+      concurrent-ruby (~> 1.0)
+    hashie (3.5.2)
+    http_parser.rb (0.6.0)
+    i18n (0.7.0)
+    kramdown (1.13.2)
+    listen (3.0.8)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    memoist (0.15.0)
+    middleman (4.2.1)
+      coffee-script (~> 2.2)
+      compass-import-once (= 1.0.5)
+      haml (>= 4.0.5)
+      kramdown (~> 1.2)
+      middleman-cli (= 4.2.1)
+      middleman-core (= 4.2.1)
+      sass (>= 3.4.0, < 4.0)
+    middleman-autoprefixer (2.7.1)
+      autoprefixer-rails (>= 6.5.2, < 7.0.0)
+      middleman-core (>= 3.3.3)
+    middleman-cli (4.2.1)
+      thor (>= 0.17.0, < 2.0)
+    middleman-core (4.2.1)
+      activesupport (>= 4.2, < 5.1)
+      addressable (~> 2.3)
+      backports (~> 3.6)
+      bundler (~> 1.1)
+      contracts (~> 0.13.0)
+      dotenv
+      erubis
+      execjs (~> 2.0)
+      fast_blank
+      fastimage (~> 2.0)
+      hamster (~> 3.0)
+      hashie (~> 3.4)
+      i18n (~> 0.7.0)
+      listen (~> 3.0.0)
+      memoist (~> 0.14)
+      padrino-helpers (~> 0.13.0)
+      parallel
+      rack (>= 1.4.5, < 3)
+      sass (>= 3.4)
+      servolux
+      tilt (~> 2.0)
+      uglifier (~> 3.0)
+    middleman-livereload (3.4.6)
+      em-websocket (~> 0.5.1)
+      middleman-core (>= 3.3)
+      rack-livereload (~> 0.3.15)
+    minitest (5.10.1)
+    neat (1.8.0)
+      sass (>= 3.3)
+      thor (~> 0.19)
+    padrino-helpers (0.13.3.3)
+      i18n (~> 0.6, >= 0.6.7)
+      padrino-support (= 0.13.3.3)
+      tilt (>= 1.4.1, < 3)
+    padrino-support (0.13.3.3)
+      activesupport (>= 3.1)
+    parallel (1.10.0)
+    public_suffix (2.0.5)
+    rack (2.0.1)
+    rack-livereload (0.3.16)
+      rack
+    rb-fsevent (0.9.8)
+    rb-inotify (0.9.8)
+      ffi (>= 0.5.0)
+    redcarpet (3.4.0)
+    sass (3.4.23)
+    servolux (0.12.0)
+    thor (0.19.4)
+    thread_safe (0.3.5)
+    tilt (2.0.6)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    uglifier (3.0.4)
+      execjs (>= 0.3.0, < 3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bourbon
+  builder
+  middleman
+  middleman-autoprefixer
+  middleman-livereload
+  neat
+  redcarpet
+  sass
+
+BUNDLED WITH
+   1.14.3


### PR DESCRIPTION
This was ignored back in https://github.com/middleman/middleman-guides/commit/73dd39dddaa4d329b17ea4f20acd9792bc25e0f4 when this repo was a Middleman template.

Now that this is a full Middleman instance, it's useful to check the Gemfile.lock file into version control. More info on that on the Bundler website: http://bundler.io/v1.3/rationale.html#checking-your-code-into-version-control