### PR TITLE
Add lang attribute to html element in layout

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="<%= I18n.locale %>">
   <head>
     <meta charset="utf-8">
     <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible">


### PR DESCRIPTION
The HTML `lang` attribute is used to identify the language of text
content on the page. Among other things, it will help screen readers
switch language profiles to provide the correct accent and
pronunciation.

See: https://www.paciellogroup.com/blog/2016/06/using-the-html-lang-attribute/