### PR TITLE
Tracking

### DIFF
--- a/source/partials/_tracking.erb
+++ b/source/partials/_tracking.erb
@@ -1,25 +1,30 @@
-<script>
-  var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', 'UA-90027-21']);
-  _gaq.push(['_trackPageview']);
+<% if ENV["GOOGLE_ANALYTICS_ID"] %>
+  <script>
+    var _gaq = _gaq || [];
+    _gaq.push(['_setAccount', '<%= ENV["GOOGLE_ANALYTICS_ID"] %>']);
+    _gaq.push(['_trackPageview']);
 
-  (function() {
-    var ga = document.createElement('script');
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-    ga.setAttribute('async', 'true');
-    document.documentElement.firstChild.appendChild(ga);
-  })();
-</script>
-<script>
-  var _gauges = _gauges || [];
-  (function() {
-    var t   = document.createElement('script');
-    t.type  = 'text/javascript';
-    t.async = true;
-    t.id    = 'gauges-tracker';
-    t.setAttribute('data-site-id', '4ef39d56613f5d017b000004');
-    t.src = '//secure.gaug.es/track.js';
-    var s = document.getElementsByTagName('script')[0];
-    s.parentNode.insertBefore(t, s);
-  })();
-</script>
+    (function() {
+      var ga = document.createElement('script');
+      ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+      ga.setAttribute('async', 'true');
+      document.documentElement.firstChild.appendChild(ga);
+    })();
+  </script>
+<% end %>
+
+<% if ENV["GAUGES_ID"] %>
+  <script>
+    var _gauges = _gauges || [];
+    (function() {
+      var t   = document.createElement('script');
+      t.type  = 'text/javascript';
+      t.async = true;
+      t.id    = 'gauges-tracker';
+      t.setAttribute('data-site-id', '<%= ENV["GAUGES_ID"] %>');
+      t.src = '//secure.gaug.es/track.js';
+      var s = document.getElementsByTagName('script')[0];
+      s.parentNode.insertBefore(t, s);
+    })();
+  </script>
+<% end %>

--- a/source/partials/_tracking.erb
+++ b/source/partials/_tracking.erb
@@ -1,15 +1,12 @@
 <% if ENV["GOOGLE_ANALYTICS_ID"] %>
   <script>
-    var _gaq = _gaq || [];
-    _gaq.push(['_setAccount', '<%= ENV["GOOGLE_ANALYTICS_ID"] %>']);
-    _gaq.push(['_trackPageview']);
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-    (function() {
-      var ga = document.createElement('script');
-      ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-      ga.setAttribute('async', 'true');
-      document.documentElement.firstChild.appendChild(ga);
-    })();
+    ga('create', '<%= ENV["GOOGLE_ANALYTICS_ID"] %>', 'auto');
+    ga('send', 'pageview');
   </script>
 <% end %>
 


### PR DESCRIPTION
This allows for the tracking services to only be injected within certain environments, like in production, but not in development.

I believe we are hosting through [Netlify](https://www.netlify.com/) which [allows us to set build environment variables](https://www.netlify.com/docs/continuous-deployment/#build-environment-variables), so we can set `GOOGLE_ANALYTICS_ID` and `GAUGES_ID` there.

We could also utilize something like [middleman-dotenv](https://github.com/middleman-contrib/middleman-dotenv).