### PR TITLE
Use system fonts

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -5,7 +5,6 @@
     <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <title><%= page_title %></title>
-    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Source+Code+Pro">
     <%= stylesheet_link_tag "site" %>
   </head>
   <body>

--- a/source/stylesheets/base/_variables.scss
+++ b/source/stylesheets/base/_variables.scss
@@ -2,8 +2,11 @@
 @include disable-prefix-for-all;
 
 // Typography
-$sans-serif: "Lato", $helvetica;
-$monospace-font-family: "Source Code Pro", $monospace;
+$sans-serif: -apple-system, BlinkMacSystemFont, "Avenir Next", "Avenir",
+  "Segoe UI", "Lucida Grande", "Helvetica Neue", "Helvetica", "Fira Sans",
+  "Roboto", "Noto", "Droid Sans", "Cantarell", "Oxygen", "Ubuntu",
+  "Franklin Gothic Medium", "Century Gothic", "Liberation Sans", sans-serif;
+$monospace-font-family: "Consolas", "monaco", monospace;
 
 $base-font-family: $sans-serif;
 $header-font-family: $base-font-family;


### PR DESCRIPTION
By switching to system fonts we maintain a similar look and feel, while eliminating the need for loading external resources: fonts from Google.

In my opinion, San Francisco (Apple’s system font, shown below) has a more rigid feel than Lato (the currently used Google font) which I think better aligns with the structure of the Middleman logo. A win-win.

The font stack comes from https://github.com/mrmrs/css-system-fonts.

Note that Bourbon v5 will ship with a `$font-stack-system` variable, so this long list can be wrapped up simply as `font-family: $font-stack-system;` once we upgrade from v4.

## Before

![screen shot 2017-02-12 at 10 14 15](https://cloud.githubusercontent.com/assets/903327/22863331/19d9ca52-f10c-11e6-829f-e9fd0c54a842.png)

## After

![screen shot 2017-02-12 at 09 57 16](https://cloud.githubusercontent.com/assets/903327/22863332/222c65fc-f10c-11e6-8f41-f9ac07dc36a2.png)
