### PR TITLE
Fix broken asset link

### DIFF
--- a/source/stylesheets/modules/_browser.scss
+++ b/source/stylesheets/modules/_browser.scss
@@ -5,7 +5,7 @@
 
 .browser:before {
   @include size(100% em(27));
-  background: $browser-bar-color inline-image("browser-bar-button-set.svg") no-repeat 0.5em 0.5em;
+  background: $browser-bar-color url("../images/browser-bar-button-set.svg") no-repeat 0.5em 0.5em;
   border-radius: $base-border-radius $base-border-radius 0 0;
   content: "";
   display: block;


### PR DESCRIPTION
This CSS asset link was busted and causing the “fake browser bars” on the home page to not show at all:

## Before

![screen shot 2017-02-13 at 22 21 09](https://cloud.githubusercontent.com/assets/903327/22913783/e80b266c-f23a-11e6-98c0-35f236d3ea88.png)

## After

![screen shot 2017-02-13 at 22 21 29](https://cloud.githubusercontent.com/assets/903327/22913786/ebfad362-f23a-11e6-9d58-82989872d152.png)
