### PR TITLE
Tweak Middleman yellow color

### DIFF
--- a/source/stylesheets/base/_variables.scss
+++ b/source/stylesheets/base/_variables.scss
@@ -39,7 +39,7 @@ $dark-gray: #4a4e56;
 $medium-gray: #999;
 
 // Middleman colors
-$mm-yellow: #f3c859;
+$mm-yellow: #fbc547;
 $mm-navy: #446184;
 $mm-slate-gray: #8990a1;
 $mm-light-gray: #c0c0c0;


### PR DESCRIPTION
The current yellow felt a little dull to me, so I’m trying out a deeper, more golden yellow.

(current on the left, updated on the right)

![screen shot 2017-02-14 at 09 10 03](https://cloud.githubusercontent.com/assets/903327/22932457/f89f4e30-f295-11e6-90f6-eaf7a1fbb8f6.png)
