### PR TITLE
Add `aria-label` to docs search

### DIFF
--- a/source/partials/_docsearch.erb
+++ b/source/partials/_docsearch.erb
@@ -1,6 +1,6 @@
 <form action="javascript:void(0);" novalidate="novalidate" class="searchbox">
   <div class='searchbox__wrapper' role='search'>
-    <input autocomplete='off' class='searchbox__input' id='search-input' name='search' placeholder='<%= t("global_navigation.search_placeholder") %>' required='required' type='search'>
+    <input autocomplete='off' class='searchbox__input' id='search-input' name='search' placeholder='<%= t("global_navigation.search_placeholder") %>' required='required' type='search' aria-label="<%= t("global_navigation.search_placeholder") %>">
     <div class='searchbox__submit'>
       <svg aria-label='Search' role='img'>
         <use xlink:href='#sbx-icon-search-21' xmlns:xlink='http://www.w3.org/1999/xlink'></use>


### PR DESCRIPTION
Form elements without labels present accessibility issues.

See: https://dequeuniversity.com/rules/axe/2.1/label?application=axeChrome