### PR TITLE
Move redirect handling to Netlify

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -10,32 +10,13 @@ end
 set :markdown, tables: true, autolink: true, gh_blockcode: true, fenced_code_blocks: true, with_toc_data: false
 set :markdown_engine, :redcarpet
 
-# Redirect from old paths
-{
-  "basics/dynamic-pages.html"            => "advanced/dynamic_pages.html",
-  "basics/pretty-urls.html"              => "advanced/pretty_urls.html",
-  "advanced/custom.html"                 => "advanced/custom_extensions.html",
-  "basics/templates.html"                => "basics/templating_language.html",
-  "basics/helpers.html"                  => "basics/helper_methods.html",
-  "basics/getting-started.html"          => "basics/install.html",
-  "basics/asset-pipeline.html"           => "advanced/asset_pipeline.html",
-  "advanced/custom-templates/index.html" => "advanced/project_templates.html",
-  "advanced/improving-cacheability.html" => "advanced/improving_cacheability.html",
-  "advanced/local-data.html"             => "advanced/data_files.html",
-  "advanced/rack-middleware.html"        => "advanced/rack_middleware.html",
-  "advanced/file-size-optimization.html" => "advanced/file_size_optimization.html",
-  "community/built-using-middleman.html" => "community/built_using_middleman.html"
-}.each do |old_path, new_path|
-  ["", "jp/"].each do |prefix|
-    redirect "#{prefix}#{old_path}", to: "#{prefix}#{new_path}"
-  end
-end
-
 activate :external_pipeline,
   name: :webpack,
   command: build? ? './node_modules/webpack/bin/webpack.js --bail' : './node_modules/webpack/bin/webpack.js --watch -d',
   source: ".tmp/dist",
   latency: 1
+
+proxy "_redirects", "netlify-redirects", ignore: true
 
 configure :development do
   activate :livereload do |reload|

--- a/source/netlify-redirects
+++ b/source/netlify-redirects
@@ -1,0 +1,27 @@
+/basics/dynamic-pages                  /advanced/dynamic_pages               301
+/basics/pretty-urls                    /advanced/pretty_urls                 301
+/advanced/custom                       /advanced/custom_extensions           301
+/basics/templates                      /basics/templating_language           301
+/basics/helpers                        /basics/helper_methods                301
+/basics/getting-started                /basics/install                       301
+/basics/asset-pipeline                 /advanced/asset_pipeline              301
+/advanced/custom-templates             /advanced/project_templates           301
+/advanced/improving-cacheability       /advanced/improving_cacheability      301
+/advanced/local-data                   /advanced/data_files                  301
+/advanced/rack-middleware              /advanced/rack_middleware             301
+/advanced/file-size-optimization       /advanced/file_size_optimization      301
+/community/built-using-middleman       /community/built_using_middleman      301
+
+/jp/basics/dynamic-pages               /jp/advanced/dynamic_pages            301
+/jp/basics/pretty-urls                 /jp/advanced/pretty_urls              301
+/jp/advanced/custom                    /jp/advanced/custom_extensions        301
+/jp/basics/templates                   /jp/basics/templating_language        301
+/jp/basics/helpers                     /jp/basics/helper_methods             301
+/jp/basics/getting-started             /jp/basics/install                    301
+/jp/basics/asset-pipeline              /jp/advanced/asset_pipeline           301
+/jp/advanced/custom-templates          /jp/advanced/project_templates        301
+/jp/advanced/improving-cacheability    /jp/advanced/improving_cacheability   301
+/jp/advanced/local-data                /jp/advanced/data_files               301
+/jp/advanced/rack-middleware           /jp/advanced/rack_middleware          301
+/jp/advanced/file-size-optimization    /jp/advanced/file_size_optimization   301
+/jp/community/built-using-middleman    /jp/community/built_using_middleman   301


### PR DESCRIPTION
Since Middleman is simply a static site generator, it's limited in how
it can handle redirects. The meta refresh tags it outputs are not
accessible or SEO-friendly, and they don't send 301 redirect headers.

Netlify, which this website is hosted on, allows us to configure
redirects server-side, which resolves all of these problems.

https://www.netlify.com/docs/redirects/

Note that Netlify needs a `_redirects` file at the root of the site, but
because Middleman ignores files that begin with an underscore, a
`_redirects` file would not be output into the built site. To get around
this, a proxy is used to rename the file from `redirects` to
`_redirects` on build.