### PR TITLE
Remove duplicate link

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -28,7 +28,6 @@ en:
       external_pipeline: External Pipeline
       configuration: Configuring Your Site
       custom_extensions: Custom Extensions
-      custom_templates: Custom Templates
       data_files: Data Files
       development_optimization: Development Optimization
       dynamic_pages: Dynamic Pages

--- a/locales/jp.yml
+++ b/locales/jp.yml
@@ -28,7 +28,6 @@ jp:
       external_pipeline: 外部パイプライン
       configuration: 設定
       custom_extensions: カスタム拡張
-      custom_templates: カスタムテンプレート
       data_files: データファイル
       development_optimization: 開発の最適化
       dynamic_pages: 動的ページ

--- a/source/partials/_documentation_nav.erb
+++ b/source/partials/_documentation_nav.erb
@@ -83,9 +83,6 @@
       <li class="doc-item">
         <%= active_link_to t("navigation.advanced.custom_extensions"), "#{locale_prefix}/advanced/custom_extensions/" %>
         </li>
-      <li class="doc-item">
-        <%= active_link_to t("navigation.advanced.custom_templates"), "#{locale_prefix}/advanced/custom-templates/" %>
-        </li>
     </ul>
   </div>
 


### PR DESCRIPTION
This `/advanced/custom-templates/` link redirects to
`/advanced/project_templates/`, which is already in the nav on Line 51.

The redirect is in place on Line 22 in `config.rb`.