### PR TITLE
Change repo name to middlemanapp.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Middleman Guides
 ================
 
-These are the source files that power the [Middleman guides site](https://middlemanapp.com/),
+These are the source files that power the [Middleman website](https://middlemanapp.com/),
 which is itself a [Middleman](https://github.com/middleman/middleman)-powered static page.
 
 The guides are the primary documentation for Middleman, explaining the core features and extensions as well as pointing out community extensions.

--- a/helpers/guide_helpers.rb
+++ b/helpers/guide_helpers.rb
@@ -13,7 +13,7 @@ module GuideHelpers
 
   def edit_guide_url
     p = Pathname(current_page.source_file).relative_path_from(Pathname(root))
-    "https://github.com/middleman/middleman-guides/blob/master/#{p}"
+    "https://github.com/middleman/middlemanapp.com/blob/master/#{p}"
   end
 
   def locale_prefix

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "middleman-guides",
+  "name": "middlemanapp.com",
   "version": "1.0.0",
-  "description": "Middleman Documentation",
+  "description": "Middleman Website",
   "main": "source/javascripts/site.js",
   "private": true,
   "scripts": {
@@ -9,14 +9,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/middleman/middleman-guides.git"
+    "url": "https://github.com/middleman/middlemanapp.com.git"
   },
   "author": "Thomas Reynolds <me@tdreyno.com>",
-  "license": "MIT",
+  "license": "Creative Commons Attribution 3.0 Unported",
   "bugs": {
-    "url": "https://github.com/middleman/middleman-guides/issues"
+    "url": "https://github.com/middleman/middlemanapp.com/issues"
   },
-  "homepage": "https://github.com/middleman/middleman-guides#readme",
+  "homepage": "https://www.middlemanapp.com/",
   "dependencies": {
     "anchor-js": "^2.0.0",
     "jquery": "^2.1.4",

--- a/source/localizable/community/built-using-middleman.html.erb
+++ b/source/localizable/community/built-using-middleman.html.erb
@@ -4,10 +4,11 @@ title: Sites Built Using Middleman
 
 <div class="c-container">
   <p>These are sites that are built using Middleman.</p>
+
   <p>
     <%= link_to(
       t("built.fork"),
-      "https://github.com/middleman/middleman-guides/blob/master/data/sites.yml"
+      "https://github.com/middleman/middlemanapp.com/blob/master/data/sites.yml"
     ) %>
   </p>
 


### PR DESCRIPTION
Just need to swap the name in https://github.com/middleman/middleman-guides/settings with the changes in this PR.

Closes https://github.com/middleman/middleman-guides/issues/649