### PR TITLE
Disable Travis CI email notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
 before_install: "nvm install node"
 install: "bin/setup"
+notifications:
+  email: false
 script: "bundle exec middleman build --verbose"
 sudo: false


### PR DESCRIPTION
Personally, the PR status is enough for me to be notified of a broken build. I wish Travis let us set this to only send emails when `master` was broken, but they don’t have that setting.

Thoughts on turning emails off?